### PR TITLE
uri에서 문자열 'images', 'artists' 체크를 변경, 에러반영

### DIFF
--- a/archive/views/api/artists.py
+++ b/archive/views/api/artists.py
@@ -56,7 +56,11 @@ def modify(id):
             continue
         result_param[param] = params.get(param)
 
-    artist = Artist.query.filter(Artist.id == id).update(result_param)
+    artist = Artist.query.filter(Artist.id == id)
+
+    if not artist.all():
+        abort(404)
+    artist = artist.update(result_param)
     Artist.query.session.commit()
 
     return jsonify(
@@ -70,6 +74,8 @@ def detail(id):
 
     artist = Artist.query.get_or_404(id)
     images = Image.query.filter(Image.artist_id == id).all()
+    if not images:
+        abort(404)
 
     content = artist.detail_to_dict(images)
 
@@ -83,7 +89,11 @@ def detail(id):
 def delete(id):
 
     image = Image.query.filter(Image.artist_id == id).delete()
-    artist = Artist.query.filter(Artist.id == id).delete()
+    artist = Artist.query.filter(Artist.id == id)
+
+    if not artist.all():
+        abort(404)
+    artist.delete()
 
     Image.query.session.commit()
     Artist.query.session.commit()

--- a/archive/views/api/errors/error_handler.py
+++ b/archive/views/api/errors/error_handler.py
@@ -2,16 +2,21 @@ from archive import app
 
 from flask import request, jsonify
 
+import os
+
 
 @app.errorhandler(404)
 def error404(e):
 
     error_message = ""
 
+    images = os.environ.get('IMAGE')
+    artists = os.environ.get('ARTIST')
+
     if request.method == 'PUT' or request.method == 'DELETE':
-        if 'artists' in request.url:
+        if artists in request.url:
             error_message = "Artist is not exist"
-        elif 'images' in request.url:
+        elif images in request.url:
             error_message = "Image is not exist"
     else:
         error_message = "Data doesnt't exist"

--- a/archive/views/api/images.py
+++ b/archive/views/api/images.py
@@ -75,7 +75,11 @@ def images_detail(id):
 def images_update(id):
 
     params = request.values
-    image = Image.query.filter(Image.id == id).update(params)
+    image = Image.query.filter(Image.id == id)
+
+    if not images.all():
+        abort(404)
+    image.update(params)
 
     Image.query.session.commit()
 
@@ -88,7 +92,12 @@ def images_update(id):
 @app.route('/api/images/<id>', methods=['DELETE'])
 def images_delete(id):
 
-    image = Image.query.filter(Image.id == id).delete()
+    image = Image.query.filter(Image.id == id)
+
+    if not image.all():
+        abort(404)
+
+    image.delete()
 
     Image.query.session.commit()
 


### PR DESCRIPTION
uri 문자열에 images, artists에 따라 에러메세지를 다르게 해주기 위해
직접 문자열을 넣어서 체크하였는데
설계가 변경되었을 경우, .env 한 곳에서만 변경하면 되도록하기 위해
os.environ.get('IMAGE'), os.environ.get('ARTIST')로 변경

.env에서는
export IMAGE='images'
export ARTIST='artists' 로 입력이 되어있음

그리고 put, delete 에서는 없는 데이터를 찾아도 true가 반환됨,
그래서 where로 검색했을경우 무조건 404 에러가 발생되도록 수정함
